### PR TITLE
Allow running from any directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The following directions were tested on BitCurator 1.5.11. The following install
   * `git clone https://github.com/simsong/dfxml/`
   * `cd ../tests`
   * `git clone https://github.com/dfxml-working-group/dfxml_schema`
-  * To run, you should be in the `hfs2dfxml/hfs2dfxml` directory
 
 ## How to use
 To generate DFXML for an HFS-formatted volume, navigate to the hfs2dfxml directory and use:

--- a/hfs2dfxml/hfs2dfxml.py
+++ b/hfs2dfxml/hfs2dfxml.py
@@ -22,7 +22,7 @@ from hashlib import md5
 from hashlib import sha1
 
 # Import Python DFXML Bindings
-sys.path.append('dfxml/python')
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'dfxml', 'python'))
 import Objects as DFXML
 
 


### PR DESCRIPTION
When modifying the sys.path, include the full path so that this script will run in any directory.

Another, more Pythonic, solution is to fix dfxml to import like a python package by adding `__init__.py` to `dfxml` and `dfxml/python`, and modifying the import statement, but that requires changing multiple packages.

```diff
 # Import Python DFXML Bindings
-sys.path.append('dfxml/python')
-import Objects as DFXML
+from dfxml.python import Objects as DFXML
```

These solutions should be verified with Python3 as well, since the relative/absolute import behaviour changed in python 2 vs python 3.